### PR TITLE
Fix FDL-2+ ROF logic; FDL-2+ would not respect ROF potentiometer originally

### DIFF
--- a/FDL-2+/FDL-2+_Firmware.ino
+++ b/FDL-2+/FDL-2+_Firmware.ino
@@ -1,5 +1,5 @@
 //FDL-2+ Blaster Firmware
-//Last Update: 2017-5-19
+//Last Update: 2018-04-01
 
 SYSTEM_MODE(SEMI_AUTOMATIC);
 
@@ -165,7 +165,8 @@ int getROF(){
     }
     else{
         int val = analogRead(rofSenseIn);
-        int rofPercent = map(val, 0, 4094, 0, 100);
+        int rofPercent = map(val, 0, 4094, currentSettingsStruct.lowROF, currentSettingsStruct.highROF);
+        return rofPercent;
     }
 }
 


### PR DESCRIPTION
The ROF logic was missing a return statement for the getROF code. It was properly mapping to a value between 0-100, but not ever returning the value it mapped. In addition, it was not using the web-app set settings.

I am unsure of if this has been fixed already, but I figured I could open a GitHub PR to try and push the (albeit simple) fix up to the parent repo.